### PR TITLE
Removing a root route that doesn't seem to be used, it was causing th…

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
 CkeditorWave::Engine.routes do
-  root to: 'ckeditor_wave/ck_images#list'
   scope module: 'ckeditor_wave' do
     resources :ck_images
   end
 end
-

--- a/lib/ckeditor_wave/version.rb
+++ b/lib/ckeditor_wave/version.rb
@@ -1,3 +1,3 @@
 module CkeditorWave
-  VERSION = '2.0.6'
+  VERSION = '2.0.6a'
 end


### PR DESCRIPTION
Removing a root route that was causing the following routing error:

ArgumentError
Invalid route name, already in use: 'root' You may have defined two routes with the same name using the `:as` option, or you may be overriding a route already defined by a resource with the same naming. For the latter, you can restrict the routes created with `resources` as explained here: http://guides.rubyonrails.org/routing.html#restricting-the-routes-created
Extracted source (around line #549):
        if name && named_routes[name]
          raise ArgumentError, "Invalid route name, already in use: '#{name}' \n" \
            "You may have defined two routes with the same name using the `:as` option, or " \
            "you may be overriding a route already defined by a resource with the same naming. " \
            "For the latter, you can restrict the routes created with `resources` as explained here: \n" \

Rails.root: /Users/eric/Rails/appname.org

Application Trace | Framework Trace | Full Trace
actionpack (4.2.6) lib/action_dispatch/routing/route_set.rb:549:in `add_route'
actionpack (4.2.6) lib/action_dispatch/routing/mapper.rb:1562:in `add_route'
actionpack (4.2.6) lib/action_dispatch/routing/mapper.rb:1537:in `decomposed_match'
actionpack (4.2.6) lib/action_dispatch/routing/mapper.rb:1518:in `block in match'
actionpack (4.2.6) lib/action_dispatch/routing/mapper.rb:1508:in `each'
actionpack (4.2.6) lib/action_dispatch/routing/mapper.rb:1508:in `match'
actionpack (4.2.6) lib/action_dispatch/routing/mapper.rb:387:in `root'
actionpack (4.2.6) lib/action_dispatch/routing/mapper.rb:1581:in `root'
ckeditor_wave (2.0.6) config/routes.rb:2:in `block in <top (required)>'
